### PR TITLE
add patch to change user_percent key on decks

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -128,6 +128,26 @@ describe("app", () => {
         });
     });
   });
+  describe("PATCH /api/decks/:deck_id/user-percent", () => {
+    it("responds with the updated array value and a 200 status code", () => {
+      const input = {
+        user_percent: 50,
+      };
+      return request(app)
+        .patch(`/api/decks/30540c7891af7f8b720efb8f`)
+        .send(input)
+        .expect(200)
+        .then(({ body }) => {
+          expect(body.updatedDeck).toBeInstanceOf(Object);
+          expect(body.updatedDeck).toEqual(
+            expect.objectContaining({
+              user_percent: [50],
+              _id: "30540c7891af7f8b720efb8f",
+            })
+          );
+        });
+    });
+  });
 
   describe("GET /api/decks/:deck_id/cards", () => {
     it("responds with the cards for a specific deck", () => {

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -134,12 +134,13 @@ describe("app", () => {
         user_percent: 50,
       };
       return request(app)
-        .patch(`/api/decks/30540c7891af7f8b720efb8f`)
+        .patch(`/api/decks/30540c7891af7f8b720efb8f/user-percent`)
         .send(input)
         .expect(200)
         .then(({ body }) => {
-          expect(body.updatedDeck).toBeInstanceOf(Object);
-          expect(body.updatedDeck).toEqual(
+          console.log(body);
+          expect(body.updatedUserPercent).toBeInstanceOf(Object);
+          expect(body.updatedUserPercent).toEqual(
             expect.objectContaining({
               user_percent: [50],
               _id: "30540c7891af7f8b720efb8f",

--- a/controllers/decks-controllers.js
+++ b/controllers/decks-controllers.js
@@ -3,6 +3,7 @@ const {
   createSingleDeck,
   fetchCardsByDeckId,
   updateSingleDeck,
+  updateSingleDeckForUserPercent,
 } = require("../models/decks-models");
 
 exports.getDecks = (req, res, next) => {
@@ -43,6 +44,18 @@ exports.patchSingleDeck = (req, res, next) => {
   updateSingleDeck(body, deck_id)
     .then((updatedDeck) => {
       res.status(200).send({ updatedDeck });
+    })
+    .catch((err) => {
+      next(err);
+    });
+};
+
+exports.patchSingleDeckForUserPercent = (req, res, next) => {
+  const { body } = req;
+  const deck_id = req.params.deck_id;
+  updateSingleDeckForUserPercent(body, deck_id)
+    .then((updatedUserPercent) => {
+      res.status(200).send({ updatedUserPercent });
     })
     .catch((err) => {
       next(err);

--- a/db/models/decks.js
+++ b/db/models/decks.js
@@ -4,6 +4,7 @@ const deckSchema = new mongoose.Schema({
   title: String,
   description: String,
   cards: [{ type: mongoose.Schema.Types.ObjectId, ref: "Card" }],
+  user_percent: [Number],
 });
 
 const Deck = mongoose.model("Deck", deckSchema);

--- a/models/decks-models.js
+++ b/models/decks-models.js
@@ -32,3 +32,13 @@ exports.updateSingleDeck = async (body, deck_id) => {
     return updatedDeck;
   });
 };
+
+exports.updateSingleDeckForUserPercent = async (body, deck_id) => {
+  return Deck.findByIdAndUpdate(
+    deck_id,
+    { $push: body },
+    { returnDocument: "after" }
+  ).then((updatedUserPercent) => {
+    return updatedUserPercent;
+  });
+};

--- a/routes/decks-router.js
+++ b/routes/decks-router.js
@@ -3,6 +3,7 @@ const {
   getCardsByDeckId,
   postSingleDeck,
   patchSingleDeck,
+  patchSingleDeckForUserPercent,
 } = require("../controllers/decks-controllers");
 
 const decksRouter = require("express").Router();
@@ -10,6 +11,10 @@ const decksRouter = require("express").Router();
 decksRouter.route("/").get(getDecks);
 
 decksRouter.route("/:deck_id").patch(patchSingleDeck);
+
+decksRouter
+  .route("/:deck_id/user-percent")
+  .patch(patchSingleDeckForUserPercent);
 
 decksRouter.route("/:user_id").post(postSingleDeck);
 


### PR DESCRIPTION
Added a user_percent key on the decks object. Can now update this key with patch api/decks/:deck_id/user-percent. It allows for adding multiple values in the array.